### PR TITLE
Json import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# keepy-cli 
+# keepy-cli
 
 [![Coverage Status](https://coveralls.io/repos/github/Eomm/keepy-cli/badge.svg?branch=master)](https://coveralls.io/github/Eomm/keepy-cli?branch=master) [![install size](https://packagephobia.now.sh/badge?p=keepy-cli)](https://packagephobia.now.sh/result?p=keepy-cli)
 ![Build Status](https://github.com/Eomm/keepy-cli/workflows/Test/badge.svg)
@@ -35,7 +35,7 @@ from `keepy <command>` ➡️ to `npx keepy-cli <command>`
 
 ## Features
 
-Check the [man](man/) directory to see all the arguments detail or type `npx keepy-cli help` 
+Check the [man](man/) directory to see all the arguments detail or type `npx keepy-cli help`
 to get a preview.
 
 ### Init
@@ -60,7 +60,9 @@ keepy add [--key|-k <string>]
           [--tags|-t <string 1> <string 2> <string n>]
           [--help|-h]
 ```
-This command adds one key to the keepy-store.json. If you set a file, all the keys will be added with the input tags.
+This command adds one key to the keepy-store.json.
+If you set a file, all the keys will be added with the input tags.
+The file can be either .env (K=V) or a .json file. If you import from a JSON file the first-level keys will be the keys you have in the store at the end.
 If you set all the args `payload`, `env`, `file`, they will be evaluated in this order without overwriting.
 
 ### Restore

--- a/commands/add.js
+++ b/commands/add.js
@@ -3,7 +3,7 @@
 const askFor = require('../lib/askFor')
 const parseArgs = require('../lib/args')
 const log = require('../lib/notify')
-const { needToShowHelp, readKeyValueFile } = require('../lib/help')
+const { needToShowHelp, extractPayloadFromFile } = require('../lib/help')
 const CryptoStorage = require('../lib/CryptoStorage')
 
 module.exports = async function (args) {
@@ -27,7 +27,7 @@ module.exports = async function (args) {
     itemPayload = process.env[itemKey]
   }
   if (opts.file && !itemPayload) {
-    itemPayload = readKeyValueFile(opts.file)
+    itemPayload = await extractPayloadFromFile(opts.file)
   }
 
   const storage = new CryptoStorage()

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,18 +1,56 @@
 'use strict'
 
 const path = require('path')
-const { readFileSync } = require('fs')
+const { readFileSync, promises: { readFile } } = require('fs')
+const { readJsonFile } = require('file-utils-easy')
 const dotenv = require('dotenv')
+const log = require('./notify')
 
-module.exports.needToShowHelp = function (file, opts) {
+function needToShowHelp (file, opts) {
   if (opts.help || opts._.length > 0) {
     console.log(readFileSync(path.join(__dirname, '..', 'man', file), 'utf8'))
     process.exit()
   }
 }
 
-module.exports.readKeyValueFile = function (file) {
-  const content = readFileSync(file, { encoding: 'utf8' })
+async function readKeyValueFile (file) {
+  const content = await readFile(file, { encoding: 'utf8' })
   const kv = dotenv.parse(content)
   return Object.entries(kv)
+}
+
+async function readKeyValueJsonFile (file) {
+  const kv = []
+  const content = await readJsonFile(file)
+  for (const [key, value] of Object.entries(content)) {
+    if (typeof value === 'object' && value !== null) {
+      log.warn(`❕key=[${key}] it's not a primitive, importing as string`)
+    }
+    kv.push([key, JSON.stringify(value)])
+  }
+  return kv
+}
+
+async function extractPayloadFromFile (file) {
+  try {
+    // Try to read as JSON in any case
+    return await readKeyValueJsonFile(file)
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      // If the extension was explicit but the JSON if malformed, it's be better to raise an error and return
+      if (file.trim().endsWith('.json')) {
+        return log.error(`❌ given '${file}' is not a valid JSON file`, 1)
+      }
+      // Eventually try to read as key-value file
+      return await readKeyValueFile(file)
+    }
+    return log.error(`❌ unexpected error: ${error.message}\n${error.stack}`, 1)
+  }
+}
+
+module.exports = {
+  needToShowHelp,
+  readKeyValueFile,
+  readKeyValueJsonFile,
+  extractPayloadFromFile
 }

--- a/lib/help.js
+++ b/lib/help.js
@@ -26,7 +26,7 @@ async function readKeyValueJsonFile (file) {
     if (typeof value === 'object' && value !== null) {
       log.warn(`❕key=[${key}] it's not a primitive, importing as string`)
     }
-    kv.push([key, JSON.stringify(value)])
+    kv.push([key, typeof value === 'string' ? value : JSON.stringify(value)])
   }
   return kv
 }

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -6,6 +6,7 @@ class Notify {
   constructor () {
     this.colors = {
       debug: chalk.blue,
+      warn: chalk.yellow,
       info: chalk.green,
       error: chalk.red
     }
@@ -17,6 +18,10 @@ class Notify {
 
   info (msg) {
     console.log(this.colors.info(msg))
+  }
+
+  warn (msg) {
+    console.log(this.colors.warn(msg))
   }
 
   error (msg, exitCode = 0) {

--- a/man/add.txt
+++ b/man/add.txt
@@ -8,7 +8,7 @@ Usage: keepy add [--key|-k <string>] [--payload|-p <string>] [--file|-f <file pa
       The value of the key
 
   -f, --file <file path>
-      File in K=V format to store in keepy-store. Ex: .env
+      File to store in keepy-store. Either in K=V format (ex: .env) or JSON format (ex: file.json).
 
   -u, --update
       Update the key's value if exists, otherwise the key will be added also if duplicated

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -25,7 +25,7 @@ test('parse all args', t => {
   ]
   const parsedArgs = parseArgs(argv)
 
-  t.strictDeepEqual(parsedArgs, {
+  t.strictSame(parsedArgs, {
     _: [],
     update: true,
     env: true,
@@ -46,7 +46,7 @@ test('check default values', t => {
   t.plan(1)
   const parsedArgs = parseArgs([])
 
-  t.strictDeepEqual(parsedArgs, {
+  t.strictSame(parsedArgs, {
     _: [],
     update: false,
     env: false,
@@ -83,7 +83,7 @@ test('parse args with = assignment', t => {
   ]
   const parsedArgs = parseArgs(argv)
 
-  t.strictDeepEqual(parsedArgs, {
+  t.strictSame(parsedArgs, {
     _: [],
     update: true,
     env: true,
@@ -120,7 +120,7 @@ test('parse args aliases', t => {
   ]
   const parsedArgs = parseArgs(argv)
 
-  t.strictDeepEqual(parsedArgs, {
+  t.strictSame(parsedArgs, {
     _: [],
     update: true,
     env: true,
@@ -157,7 +157,7 @@ test('parse numbers as string', t => {
   ]
   const parsedArgs = parseArgs(argv)
 
-  t.strictDeepEqual(parsedArgs, {
+  t.strictSame(parsedArgs, {
     _: [],
     update: true,
     env: true,

--- a/test/commands/add.test.js
+++ b/test/commands/add.test.js
@@ -15,9 +15,9 @@ test('right usage', t => {
 
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 1)
-    t.deepEquals(ks.data[0].tags, [])
+    t.equal(code, 0)
+    t.equal(ks.data.length, 1)
+    t.same(ks.data[0].tags, [])
   })
 })
 
@@ -29,11 +29,11 @@ test('import file env', t => {
   const cli = spawn(node, ['cli', 'add', '-f', importFile, '-t', 'from-file', '-w', 'ciao'])
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 3)
-    t.equals(ks.data[0].tags.length, 1)
-    t.equals(ks.data[1].tags.length, 1)
-    t.equals(ks.data[2].tags.length, 1)
+    t.equal(code, 0)
+    t.equal(ks.data.length, 3)
+    t.equal(ks.data[0].tags.length, 1)
+    t.equal(ks.data[1].tags.length, 1)
+    t.equal(ks.data[2].tags.length, 1)
   })
 })
 
@@ -45,11 +45,11 @@ test('import file json plain', t => {
   const cli = spawn(node, ['cli', 'add', '-f', importFile, '-t', 'from-file', '-w', 'ciao'])
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 3)
-    t.equals(ks.data[0].tags.length, 1)
-    t.equals(ks.data[1].tags.length, 1)
-    t.equals(ks.data[2].tags.length, 1)
+    t.equal(code, 0)
+    t.equal(ks.data.length, 3)
+    t.equal(ks.data[0].tags.length, 1)
+    t.equal(ks.data[1].tags.length, 1)
+    t.equal(ks.data[2].tags.length, 1)
   })
 })
 
@@ -76,14 +76,14 @@ test('import file json nested', t => {
     const ks = h.readKeepyStore()
     t.match(logged, /.*ARR1.*it's not a primitive, importing as string.*/)
     t.match(logged, /.*OBJ1.*it's not a primitive, importing as string.*/)
-    t.equals(code, 0)
-    t.equals(ks.data.length, 6)
-    t.equals(ks.data[0].tags.length, 1)
-    t.equals(ks.data[1].tags.length, 1)
-    t.equals(ks.data[2].tags.length, 1)
-    t.equals(ks.data[3].tags.length, 1)
-    t.equals(ks.data[4].tags.length, 1)
-    t.equals(ks.data[5].tags.length, 1)
+    t.equal(code, 0)
+    t.equal(ks.data.length, 6)
+    t.equal(ks.data[0].tags.length, 1)
+    t.equal(ks.data[1].tags.length, 1)
+    t.equal(ks.data[2].tags.length, 1)
+    t.equal(ks.data[3].tags.length, 1)
+    t.equal(ks.data[4].tags.length, 1)
+    t.equal(ks.data[5].tags.length, 1)
   })
 })
 
@@ -99,12 +99,12 @@ test('update imported file env', t => {
   })
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 4)
-    t.notEqual(ks.data[0].payload, 'XIXTTBmVymD1NLlXXKJFdeH7diUjcaK7AIKSDZ6rbqFTDCFba+HnnNIQSv9cMH1AWuu9g70FHOF4BmLWF89q50uQcjKPbWlZOGm54SsGEICCTdHneA==')
-    t.equals(ks.data[1].payload, 'ZdHit+d2u4pDKvejNIg27krC26WEZQ3oalSVhqyKSUb0QKl/yR5IYibuB2/nznmT47sdokd+jYY33MZ8DCIDcuW1dpjy1WE+bbp9QbxAEZnHyqa/GQ==')
-    t.notEqual(ks.data[2].payload, 'qLYcL3yCif2sFdxqpwRlqiR2ZnPFAaMd2lfjXYynWPviiYTRC5lSKceH29UDEtkMQQ2YliDMO+TX8Oq92F+UBa/v03IqZ+InF5QgZcbgRhDX9/sAbg==')
-    t.notEqual(ks.data[3].payload, 'ZaCkkm++dGHo6EAuaDjTFH0+0ObwYSj9wpo5fTzujeNKyEv0rOBVGN7oeEwq5+tq5FhBgxRtTtyikW37+HdSJo5B697J+fEu5eJOdraImymyTsHDWQ==')
+    t.equal(code, 0)
+    t.equal(ks.data.length, 4)
+    t.not(ks.data[0].payload, 'XIXTTBmVymD1NLlXXKJFdeH7diUjcaK7AIKSDZ6rbqFTDCFba+HnnNIQSv9cMH1AWuu9g70FHOF4BmLWF89q50uQcjKPbWlZOGm54SsGEICCTdHneA==')
+    t.equal(ks.data[1].payload, 'ZdHit+d2u4pDKvejNIg27krC26WEZQ3oalSVhqyKSUb0QKl/yR5IYibuB2/nznmT47sdokd+jYY33MZ8DCIDcuW1dpjy1WE+bbp9QbxAEZnHyqa/GQ==')
+    t.not(ks.data[2].payload, 'qLYcL3yCif2sFdxqpwRlqiR2ZnPFAaMd2lfjXYynWPviiYTRC5lSKceH29UDEtkMQQ2YliDMO+TX8Oq92F+UBa/v03IqZ+InF5QgZcbgRhDX9/sAbg==')
+    t.not(ks.data[3].payload, 'ZaCkkm++dGHo6EAuaDjTFH0+0ObwYSj9wpo5fTzujeNKyEv0rOBVGN7oeEwq5+tq5FhBgxRtTtyikW37+HdSJo5B697J+fEu5eJOdraImymyTsHDWQ==')
   })
 })
 
@@ -120,12 +120,12 @@ test('update imported file json plain', t => {
   })
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 4)
-    t.notEqual(ks.data[0].payload, 'XIXTTBmVymD1NLlXXKJFdeH7diUjcaK7AIKSDZ6rbqFTDCFba+HnnNIQSv9cMH1AWuu9g70FHOF4BmLWF89q50uQcjKPbWlZOGm54SsGEICCTdHneA==')
-    t.equals(ks.data[1].payload, 'ZdHit+d2u4pDKvejNIg27krC26WEZQ3oalSVhqyKSUb0QKl/yR5IYibuB2/nznmT47sdokd+jYY33MZ8DCIDcuW1dpjy1WE+bbp9QbxAEZnHyqa/GQ==')
-    t.notEqual(ks.data[2].payload, 'qLYcL3yCif2sFdxqpwRlqiR2ZnPFAaMd2lfjXYynWPviiYTRC5lSKceH29UDEtkMQQ2YliDMO+TX8Oq92F+UBa/v03IqZ+InF5QgZcbgRhDX9/sAbg==')
-    t.notEqual(ks.data[3].payload, 'ZaCkkm++dGHo6EAuaDjTFH0+0ObwYSj9wpo5fTzujeNKyEv0rOBVGN7oeEwq5+tq5FhBgxRtTtyikW37+HdSJo5B697J+fEu5eJOdraImymyTsHDWQ==')
+    t.equal(code, 0)
+    t.equal(ks.data.length, 4)
+    t.not(ks.data[0].payload, 'XIXTTBmVymD1NLlXXKJFdeH7diUjcaK7AIKSDZ6rbqFTDCFba+HnnNIQSv9cMH1AWuu9g70FHOF4BmLWF89q50uQcjKPbWlZOGm54SsGEICCTdHneA==')
+    t.equal(ks.data[1].payload, 'ZdHit+d2u4pDKvejNIg27krC26WEZQ3oalSVhqyKSUb0QKl/yR5IYibuB2/nznmT47sdokd+jYY33MZ8DCIDcuW1dpjy1WE+bbp9QbxAEZnHyqa/GQ==')
+    t.not(ks.data[2].payload, 'qLYcL3yCif2sFdxqpwRlqiR2ZnPFAaMd2lfjXYynWPviiYTRC5lSKceH29UDEtkMQQ2YliDMO+TX8Oq92F+UBa/v03IqZ+InF5QgZcbgRhDX9/sAbg==')
+    t.not(ks.data[3].payload, 'ZaCkkm++dGHo6EAuaDjTFH0+0ObwYSj9wpo5fTzujeNKyEv0rOBVGN7oeEwq5+tq5FhBgxRtTtyikW37+HdSJo5B697J+fEu5eJOdraImymyTsHDWQ==')
   })
 })
 
@@ -133,7 +133,7 @@ test('missing keepy-storage', t => {
   t.plan(1)
   const cli = spawn(node, ['cli', 'add', '-k', 'A_KEY', '-p', 'value'])
   cli.on('close', (code) => {
-    t.equals(code, 1)
+    t.equal(code, 1)
   })
 })
 
@@ -146,7 +146,7 @@ test('missing mandatory params', async t => {
     return new Promise(resolve => {
       const cli = spawn(node, ['cli', 'add', ...params])
       cli.on('close', (code) => {
-        t.equals(code, 1)
+        t.equal(code, 1)
         resolve()
       })
     })
@@ -165,9 +165,9 @@ test('input password and tags', t => {
   const cli = spawn(node, ['cli', 'add', '-k', 'THE_KEY', '-p', 'value', '-t', 'hello', 'world'])
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 1)
-    t.equals(ks.data[0].tags.length, 2)
+    t.equal(code, 0)
+    t.equal(ks.data.length, 1)
+    t.equal(ks.data[0].tags.length, 2)
   })
 
   cli.stdin.setEncoding('utf-8')
@@ -183,8 +183,8 @@ test('env param', t => {
   const cli = spawn(node, ['cli', 'add', '-k', 'THE_KEY', '-p', '-e', '-w', 'ciao'], { env })
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 1)
+    t.equal(code, 0)
+    t.equal(ks.data.length, 1)
   })
 })
 
@@ -207,9 +207,9 @@ test('update param with key', async t => {
   await executeAdd(['-k', 'THE_KEY', '-p', 'newValue', '-u'])
   const ksUpdated = h.readKeepyStore()
 
-  t.equals(ksUpdated.data.length, 1)
-  t.equals(ksUpdated.data[0].tags.length, 2)
-  t.deepNot(ksInserted.data[0], ksUpdated.data[0])
+  t.equal(ksUpdated.data.length, 1)
+  t.equal(ksUpdated.data[0].tags.length, 2)
+  t.strictNotSame(ksInserted.data[0], ksUpdated.data[0])
 }).catch(threw)
 
 test('update param with key and tags', async t => {
@@ -218,25 +218,25 @@ test('update param with key and tags', async t => {
   h.createTestKeepyStore()
   await h.execute('add', ['-k', 'A', '-p', 'value', '-w', 'ciao', '-t', 'hello'])
   const ksA = h.readKeepyStore()
-  t.equals(ksA.data.length, 1)
+  t.equal(ksA.data.length, 1)
 
   await h.execute('add', ['-k', 'C', '-p', 'value', '-w', 'ciao', '-t', 'hello'])
   const ksC = h.readKeepyStore()
-  t.equals(ksC.data.length, 2)
+  t.equal(ksC.data.length, 2)
 
   // this key is added
   await h.execute('add', ['-k', 'C', '-p', 'value', '-w', 'ciao', '-t', 'hello', 'bye'])
   const ksCC = h.readKeepyStore()
-  t.equals(ksCC.data.length, 3)
+  t.equal(ksCC.data.length, 3)
 
   await h.execute('add', ['-k', 'C', '-p', 'change', '-w', 'ciao', '-t', 'bye', '-u'])
   const ksUpdated = h.readKeepyStore()
-  t.equals(ksUpdated.data.length, 3)
+  t.equal(ksUpdated.data.length, 3)
 
-  t.equals(ksCC.data[1].payload, ksUpdated.data[1].payload)
-  t.deepNot(ksCC.data[2].payload, ksUpdated.data[2].payload)
-  t.deepEquals(ksCC.data[2].key, ksUpdated.data[2].key)
-  t.deepEquals(ksCC.data[2].tags, ksUpdated.data[2].tags)
+  t.equal(ksCC.data[1].payload, ksUpdated.data[1].payload)
+  t.strictNotSame(ksCC.data[2].payload, ksUpdated.data[2].payload)
+  t.same(ksCC.data[2].key, ksUpdated.data[2].key)
+  t.same(ksCC.data[2].tags, ksUpdated.data[2].tags)
 }).catch(threw)
 
 test('update unexisting key', async t => {
@@ -254,7 +254,7 @@ test('update unexisting key', async t => {
 
   await executeAdd(['-k', 'THE_KEY', '-p', 'value', '-u'])
   const ksUpdated = h.readKeepyStore()
-  t.equals(ksUpdated.data.length, 0)
+  t.equal(ksUpdated.data.length, 0)
 }).catch(threw)
 
 test('help', t => {
@@ -263,7 +263,7 @@ test('help', t => {
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (output) => {
     const contentHelp = h.readFileHelp('add')
-    t.equals(output, contentHelp)
+    t.equal(output, contentHelp)
     t.pass()
   })
 })
@@ -274,7 +274,7 @@ test('help when wrong params', t => {
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (output) => {
     const contentHelp = h.readFileHelp('add')
-    t.equals(output, contentHelp)
+    t.equal(output, contentHelp)
     t.pass()
   })
 })
@@ -291,7 +291,7 @@ test('malformed json file', t => {
   })
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 1)
-    t.equals(ks.data.length, 4)
+    t.equal(code, 1)
+    t.equal(ks.data.length, 4)
   })
 })

--- a/test/commands/delete.test.js
+++ b/test/commands/delete.test.js
@@ -12,8 +12,8 @@ test('delete key', t => {
   const cli = spawn(node, ['cli', 'delete', '-k', 'hello', '-w', 'ciao'])
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 3)
+    t.equal(code, 0)
+    t.equal(ks.data.length, 3)
   })
 })
 
@@ -23,8 +23,8 @@ test('delete unexisting key', t => {
   const cli = spawn(node, ['cli', 'delete', '-k', 'DOESNTEXISTS'])
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 4)
+    t.equal(code, 0)
+    t.equal(ks.data.length, 4)
   })
   cli.stdin.setEncoding('utf-8')
   cli.stdin.write('ciao\n')
@@ -37,8 +37,8 @@ test('delete by tag', t => {
   const cli = spawn(node, ['cli', 'delete', '-t', 'alone', '-w', 'ciao'])
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 2)
+    t.equal(code, 0)
+    t.equal(ks.data.length, 2)
   })
 })
 
@@ -48,8 +48,8 @@ test('delete by key and tag', t => {
   const cli = spawn(node, ['cli', 'delete', '-k', 'hello3', '-t', 'alone', '-w', 'ciao'])
   cli.on('close', (code) => {
     const ks = h.readKeepyStore()
-    t.equals(code, 0)
-    t.equals(ks.data.length, 3)
+    t.equal(code, 0)
+    t.equal(ks.data.length, 3)
   })
 })
 
@@ -61,7 +61,7 @@ test('delete unexisting file', t => {
     t.match(data, /doesn't exists/gm)
   })
   cli.on('close', (code) => {
-    t.equals(code, 1)
+    t.equal(code, 1)
   })
 })
 
@@ -73,7 +73,7 @@ test('delete with missing parameters', t => {
     t.match(data, /.*mandatory.*/)
   })
   cli.on('close', (code) => {
-    t.equals(code, 1)
+    t.equal(code, 1)
   })
 })
 
@@ -83,7 +83,7 @@ test('help', t => {
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (output) => {
     const contentHelp = h.readFileHelp('delete')
-    t.equals(output, contentHelp)
+    t.equal(output, contentHelp)
     t.pass()
   })
 })
@@ -96,8 +96,8 @@ test('help when wrong params', t => {
   cli.stdout.on('data', (data) => { output += data })
   cli.on('close', (code) => {
     const contentHelp = h.readFileHelp('delete')
-    t.equals(code, 0)
-    t.equals(output, contentHelp)
+    t.equal(code, 0)
+    t.equal(output, contentHelp)
     t.pass()
   })
 })

--- a/test/commands/help.test.js
+++ b/test/commands/help.test.js
@@ -13,7 +13,7 @@ test('help', t => {
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (output) => {
     const contentHelp = h.readFileHelp('help')
-    t.equals(output, contentHelp)
+    t.equal(output, contentHelp)
     t.pass()
   })
 })
@@ -24,7 +24,7 @@ test('help when none params', t => {
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (output) => {
     const contentHelp = h.readFileHelp('help')
-    t.equals(output, contentHelp)
+    t.equal(output, contentHelp)
     t.pass()
   })
 })

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -24,10 +24,10 @@ test('basic input', async t => {
 
   const ks = h.readKeepyStore()
 
-  t.equals(ks.meta.version, version)
-  t.equals(ks.meta.hint, hint)
-  t.contains(ks.secure, { salt: /\w{0,50}/, verify: /\w{0,120}/ })
-  t.deepEquals(ks.data, [])
+  t.equal(ks.meta.version, version)
+  t.equal(ks.meta.hint, hint)
+  t.has(ks.secure, { salt: /\w{0,50}/, verify: /\w{0,120}/ })
+  t.same(ks.data, [])
 })
 
 test('input cancelled', t => {
@@ -40,7 +40,7 @@ test('input cancelled', t => {
     // t.match(data, /.*cancelled.*$/gm)
   })
   cli.on('close', (code, signal) => {
-    t.equals(signal, 'SIGINT')
+    t.equal(signal, 'SIGINT')
   })
 })
 
@@ -49,7 +49,7 @@ test('keepy-store already exists', t => {
   h.createFakeKeepyStore()
   const cli = spawn(node, ['cli', 'init'])
   cli.on('close', (code) => {
-    t.equals(code, 1)
+    t.equal(code, 1)
     t.pass()
   })
 })
@@ -59,7 +59,7 @@ test('no-input init - overwrite', t => {
   h.createFakeKeepyStore()
   const cli = spawn(node, ['cli', 'init', '-YF'])
   cli.on('close', (code) => {
-    t.equals(code, 0)
+    t.equal(code, 0)
     t.pass()
   })
 })
@@ -68,7 +68,7 @@ test('no-input init - password', t => {
   t.plan(2)
   const cli = spawn(node, ['cli', 'init', '-Y', '-w', 'password'])
   cli.on('close', (code) => {
-    t.equals(code, 0)
+    t.equal(code, 0)
     t.pass()
   })
 })
@@ -79,7 +79,7 @@ test('help', t => {
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (output) => {
     const contentHelp = h.readFileHelp('init')
-    t.equals(output, contentHelp)
+    t.equal(output, contentHelp)
     t.pass()
   })
 })
@@ -90,7 +90,7 @@ test('help when wrong params', t => {
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (output) => {
     const contentHelp = h.readFileHelp('init')
-    t.equals(output, contentHelp)
+    t.equal(output, contentHelp)
     t.pass()
   })
 })

--- a/test/commands/restore.test.js
+++ b/test/commands/restore.test.js
@@ -29,7 +29,7 @@ test('restore unexisting keystore', t => {
     t.match(data, /.*exists.*/)
   })
   cli.on('close', (code) => {
-    t.equals(code, 1)
+    t.equal(code, 1)
   })
 })
 
@@ -44,7 +44,7 @@ test('restore to stdout', t => {
   })
   cli.on('close', (code) => {
     t.match(stdout, /^hello.{0,1}=world$/gm)
-    t.equals(code, 0)
+    t.equal(code, 0)
   })
 })
 
@@ -62,7 +62,7 @@ test('restore to stdout colored', t => {
     const tags = escapeRegExp(color(' [alone]', 'tags', true))
     const re = new RegExp(`^${label}.{0,1}world${tags}$`, 'gm')
     t.match(stdout, re)
-    t.equals(code, 0)
+    t.equal(code, 0)
   })
 })
 
@@ -77,7 +77,7 @@ test('restore to stdout with tags', t => {
   })
   cli.on('close', (code) => {
     t.match(stdout, /^hello.{0,1}=world \[.*\]$/gm)
-    t.equals(code, 0)
+    t.equal(code, 0)
   })
 })
 
@@ -90,7 +90,7 @@ test('restore wrong password', t => {
     t.match(data, /.*Wrong.*$/gm)
   })
   cli.on('close', (code) => {
-    t.equals(code, 1)
+    t.equal(code, 1)
   })
 })
 
@@ -105,7 +105,7 @@ test('restore to stdout as default', t => {
   })
   cli.on('close', (code) => {
     t.match(stdout, /^hello.{0,1}=world$/gm)
-    t.equals(code, 0)
+    t.equal(code, 0)
   })
 })
 
@@ -114,13 +114,13 @@ test('restore to env', t => {
   h.createTestKeepyStoreWithKeys()
   const cli = spawn(node, ['cli', 'restore', '-e'])
   cli.on('close', (code) => {
-    t.equals(code, 0)
+    t.equal(code, 0)
 
     // ! works only after a reboot of the console on windows
     // const checkEnvVar = spawn(node, ['cli', 'add', '-k', 'hello2', '-e', '-w', 'ciao'])
     // checkEnvVar.stdout.pipe(process.stdout)
     // checkEnvVar.on('close', (code) => {
-    //   t.equals(code, 0)
+    //   t.equal(code, 0)
     // })
   })
   cli.stdin.setEncoding('utf-8')
@@ -135,7 +135,7 @@ test('restore to file', t => {
   const cli = spawn(node, ['cli', 'restore', '-f', outFile, '-w', 'ciao'])
   cli.stdout.on('data', () => { t.fail() })
   cli.on('close', (code) => {
-    t.equals(code, 0)
+    t.equal(code, 0)
     const file = readFileSync(outFile)
     t.match(file, /^hello.{0,1}=world$/gm)
   })
@@ -152,7 +152,7 @@ test('restore to existing file', t => {
     t.match(data, /already exists/gm)
   })
   cli.on('close', (code) => {
-    t.equals(code, 1)
+    t.equal(code, 1)
   })
 })
 
@@ -164,7 +164,7 @@ test('restore overwriting existing file', t => {
   const cli = spawn(node, ['cli', 'restore', '-f', outFile, '-F', '-w', 'ciao'])
   cli.stdout.on('data', () => { t.fail() })
   cli.on('close', (code) => {
-    t.equals(code, 0)
+    t.equal(code, 0)
     const file = readFileSync(outFile)
     t.match(file, /^hello.{0,1}=world$/gm)
   })
@@ -176,10 +176,10 @@ test('restore with key filter', t => {
   const cli = spawn(node, ['cli', 'restore', '-k', 'hello2', '-w', 'ciao'])
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (data) => {
-    t.equals(data, 'hello2=world\n')
+    t.equal(data, 'hello2=world\n')
   })
   cli.on('close', (code) => {
-    t.equals(code, 0)
+    t.equal(code, 0)
   })
 })
 
@@ -193,9 +193,9 @@ test('restore with tag filter', t => {
     stdout += data
   })
   cli.on('close', (code) => {
-    t.equals(code, 0)
+    t.equal(code, 0)
     t.match(stdout, /^hello.{0,1}=world$/gm)
-    t.equals(stdout.match(/hello/gm).length, 2)
+    t.equal(stdout.match(/hello/gm).length, 2)
   })
 })
 
@@ -205,10 +205,10 @@ test('restore with key and tag filter', t => {
   const cli = spawn(node, ['cli', 'restore', '-k', 'hello3', '-t', 'alone', '-w', 'ciao'])
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (data) => {
-    t.equals(data, 'hello3=world\n')
+    t.equal(data, 'hello3=world\n')
   })
   cli.on('close', (code) => {
-    t.equals(code, 0)
+    t.equal(code, 0)
   })
 })
 
@@ -219,7 +219,7 @@ test('restore unexisting key', t => {
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', () => { t.fail() })
   cli.on('close', (code) => {
-    t.equals(code, 0)
+    t.equal(code, 0)
   })
 })
 
@@ -229,7 +229,7 @@ test('help', t => {
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (output) => {
     const contentHelp = h.readFileHelp('restore')
-    t.equals(output, contentHelp)
+    t.equal(output, contentHelp)
     t.pass()
   })
 })
@@ -240,7 +240,7 @@ test('help when wrong params', t => {
   cli.stdout.setEncoding('utf8')
   cli.stdout.on('data', (output) => {
     const contentHelp = h.readFileHelp('restore')
-    t.equals(output, contentHelp)
+    t.equal(output, contentHelp)
     t.pass()
   })
 })

--- a/test/commands/version.test.js
+++ b/test/commands/version.test.js
@@ -13,7 +13,7 @@ test('right usage', t => {
     t.match(data, /keepy v\d{1,2}\.\d{1,2}\.\d{1,2}/)
   })
   cli.on('close', (code) => {
-    t.equals(code, 0)
+    t.equal(code, 0)
   })
 })
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -10,6 +10,7 @@ const { KEEPY_STORE } = require('../lib/CryptoStorage')
 beforeEach(done => { rimraf('keepy*.json', done) })
 afterEach((done) => {
   rimraf.sync('.env')
+  rimraf.sync('__test__.json')
   rimraf('keepy*.json', done)
 })
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -6,6 +6,7 @@ const rimraf = require('rimraf')
 const { spawn } = require('child_process')
 
 const { KEEPY_STORE } = require('../lib/CryptoStorage')
+const CryptoString = require('../lib/CryptoString')
 
 beforeEach(done => { rimraf('keepy*.json', done) })
 afterEach((done) => {
@@ -104,6 +105,12 @@ function execute (command, params, cb) {
   })
 }
 
+function decryptString (str, password, salt) {
+  const crypto = new CryptoString()
+  const key = crypto.getKeyFromPassword(password, Buffer.from(salt, 'base64'))
+  return crypto.decrypt(Buffer.from(str, 'base64'), key).toString('utf8')
+}
+
 module.exports = {
   wait,
   readKeepyStore,
@@ -111,5 +118,6 @@ module.exports = {
   createTestKeepyStore,
   createTestKeepyStoreWithKeys,
   readFileHelp,
-  execute
+  execute,
+  decryptString
 }


### PR DESCRIPTION
Adds support for import from JSON files (#8):
- First tries to parse the JSON in any case
- If the file has ".json" extension **and** the parse fails, then raises an error
- Otherwise goes to the K=V parsing, as it was

Takes advantage of this PR to move to non-deprecated `tap` methods.

Hope the approach makes sense!